### PR TITLE
cmake: Bump minimum required version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20)
 project(corti)
 
 # see: https://roboticsbackend.com/ros2-package-for-both-python-and-cpp-nodes/


### PR DESCRIPTION
To address deprecation warning.